### PR TITLE
chore(ci,techdept): renovate GitHub CI and Dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+tab_width = 4
+indent_size = 4
+end_of_line = lf
+indent_style = space
+max_line_length = off
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+tab_width = 2
+indent_size = 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: mvn --batch-mode clean install -DskipTests=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   build:
@@ -21,37 +24,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'oracle'
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: mvn --batch-mode clean install -DskipTests=true
+
       - name: Upload Connector
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FreeIPA Connector
-          path: ./target/connector-freeipa-1.1.1.0.jar
+          path: target/connector-freeipa-*.jar
+          if-no-files-found: error
+
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        run: |-
+          gh release create ${GIT_TAG} \
+            --title "Release ${GIT_TAG}" \
+            --generate-notes \
+            target/connector-freeipa-*.jar
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: CHANGELOG.md
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./target/connector-freeipa-1.1.1.0.jar
-          asset_name: connector-freeipa-1.1.1.0.jar
-          asset_content_type: application/java-archive
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAG: ${{ github.ref_name }} # https://docs.github.com/en/actions/reference/workflows-and-actions/variables

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Polygon/ConnId connector for FreeIPA
 
 ## Description
 
-Connector for [FreeIPA](https://www.freeipa.org/) using [REST API](https://www.freeipa.org/page/API_Examples). 
+Connector for [FreeIPA](https://www.freeipa.org/) using [REST API](https://www.freeipa.org/page/API_Examples).
 
 ## Capabilities and Features
 
@@ -13,9 +13,9 @@ Connector for [FreeIPA](https://www.freeipa.org/) using [REST API](https://www.f
 * Live Synchronization: No
 * Password: YES
 * Activation: YES
-* Script execution: No 
+* Script execution: No
 
-FreeIPA Connector contains support for USER, ROLE and GROUP entity.  
+FreeIPA Connector contains support for USER, ROLE and GROUP entity.
 
 ## Build
 
@@ -25,12 +25,16 @@ FreeIPA Connector contains support for USER, ROLE and GROUP entity.
 mvn clean install
 ```
 
-After successful the build, you can find `connector-freeipa-1.1.2.1.jar` in `target` directory.
+> [!note]
+>
+> The version number, contained within the jar name, will correspond the one set for the project within the `pom.xml`.
+
+After successful the build, you can find `connector-freeipa-x.y.z.b.jar` in `target` directory.
 
 ## Configuring resource
 
 * create user in FreeIPA
-* set membership to user groups: ipausers, trust admins, admins 
+* set membership to user groups: ipausers, trust admins, admins
 * inspire by [sample](https://github.com/inalogy/midpoint-connector-freeipa/tree/master/sample) to configure your own resource
 
 ## Debugging
@@ -38,7 +42,7 @@ After successful the build, you can find `connector-freeipa-1.1.2.1.jar` in `tar
 * Verify if service account has set password never expire, has "User authentication types" "Password" and not needed to change password at first log on.
 * Try to log in with created service account (user) to FreeIPA web GUI & verify if you have required permissions to create/update/delete user, create/update/delete groups & roles and his memberships.
 * Set up Logger for package "com.inalogy.midpoint.connectors.freeipa" to TRACE in midpoint over System/Logging/Loggers & verify midpoint.log for error details.
-* In some cases FreeIPA misconfiguration cause to return HTML error page instead of JSON and this is showed as error message in Test Connection "org.json.JSONException(A JSONObject text must begin with '{' at 1 [character 2 line 1])"
+* In some cases FreeIPA misconfiguration cause to return HTML error page instead of JSON and this is shown as error message in Test Connection "org.json.JSONException(A JSONObject text must begin with '{' at 1 [character 2 line 1])"
 * Set up Logger for package "org.apache.http" to TRACE in midpoint over System/Logging/Loggers & verify midpoint.log for other error details.
 
 ## License
@@ -47,5 +51,5 @@ Licensed under the [Apache License 2.0](/LICENSE).
 
 ## Status
 
-FreeIPA Connector is intended for production use. Tested with MidPoint version 4.6. The connector was introduced as a contribution to midPoint project by [Inalogy](https://www.inalogy.com) and is not officially supported by Evolveum.
+FreeIPA Connector is intended for production use. Tested with MidPoint version `4.9`. The connector was introduced as a contribution to midPoint project by [Inalogy](https://www.inalogy.com) and is not officially supported by Evolveum.
 If you need support, please contact info@inalogy.com.

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.5.0.0</version>
-        <relativePath></relativePath>
+        <version>1.5.2.0</version>
+        <relativePath/>
     </parent>
 
     <artifactId>connector-freeipa</artifactId>
-    <version>1.1.2.1</version>
+    <version>1.2.0.0</version>
     <packaging>jar</packaging>
 
     <name>FreeIPA Connector</name>
@@ -78,11 +78,15 @@
     </build>
     
     <dependencies>
-
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.5</version>
+        </dependency>
 		<dependency>
 			<artifactId>connector-rest</artifactId>
             <groupId>com.evolveum.polygon</groupId>
-            <version>1.4.2.35</version>
+            <version>1.5.2.0</version>
 		</dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -92,9 +96,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>20250517</version>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/src/main/java/com/inalogy/midpoint/connectors/freeipa/FreeIpaConnector.java
+++ b/src/main/java/com/inalogy/midpoint/connectors/freeipa/FreeIpaConnector.java
@@ -20,21 +20,21 @@ import java.net.URI;
 import java.util.*;
 import java.net.URISyntaxException;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.ParseException;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.BasicCookieStore;
-import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
@@ -414,7 +414,7 @@ public class FreeIpaConnector extends AbstractRestConnector<FreeIpaConfiguration
         StringEntity entity = new StringEntity( jo.toString(), ContentType.APPLICATION_JSON);
         request.setEntity(entity);
         CloseableHttpResponse response = execute(request);
-        if (response.getStatusLine().getStatusCode()==401){
+        if (response.getCode()==401){
             LOG.warn("401 - no cookie detected need to connect");
             boolean logged= login();
             if (logged){


### PR DESCRIPTION
### Description

Hi, we have recently started experimenting with Midpoint and plan to make use of it within our organisation.
As we utilise FreeIPA for our Linux Servers, we stumbled over this connector and found that the CI and it's dependencies were a bit outdated.
Since we want to be good Open Source citizens, I took the liberty to apply the necessary updates and propose them here.
Let me know if you have any feedback or need anything changed :)

### Proposed Changes

1. Updated GitHub Action Workflow
   * generally updating used actions
   * replacing deprecated actions with GitHub CLI call
   * fixing artifact upload & releasing
 2. update to project dependencies
   * `org.json:json` in the used version had several CVEs listed, so bumped to a recent version
   * `com.evolveum.polygon:connector-rest` in the used version had several CVEs listed, so bumped to a recent version
   * `org.apache.httpcomponents.client5:httpclient5` or it's predecessor was no longer implicitly included and is now explicitly added/updated
 4. introduction of [EditorConfig](https://editorconfig.org/) for uniform contribution